### PR TITLE
Adding support for ModUpdater

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = "${project.mod_version}+${project.minecraft_version}"
 group = project.maven_group
 
 dependencies {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,5 +31,11 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  "custom": {
+    "modupdater": {
+      "strategy": "curseforge",
+      "projectID": 436038
+    }
   }
 }


### PR DESCRIPTION
[ModUpdater](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater) is a mod that automatically checks mods to update them, but needs to be opted into first. I got these changes from the [developer documentation](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater/src/branch/master/MOD_DEVELOPER.md), so if I did anything wrong then please let me know