### PR TITLE
bump: 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.1
-	loader_version=0.14.11
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.2
+	loader_version=0.14.19
 
 # Mod Properties
 	mod_version = 1.4+1.19.3
@@ -13,5 +13,5 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = fast-chest
 
 # Dependencies
-	fabric_version=0.68.1+1.19.3
-	mod_menu_version=5.0.2
+	fabric_version=0.82.0+1.19.4
+	mod_menu_version=6.1.0

--- a/src/main/java/re/domi/fastchest/config/ConfigScreen.java
+++ b/src/main/java/re/domi/fastchest/config/ConfigScreen.java
@@ -65,7 +65,7 @@ public class ConfigScreen extends Screen
     public void render(MatrixStack matrices, int mouseX, int mouseY, float delta)
     {
         this.renderBackground(matrices);
-        drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 5, 0xFFFFFF);
+        drawCenteredTextWithShadow(matrices, this.textRenderer, this.title, this.width / 2, 5, 0xFFFFFF);
         super.render(matrices, mouseX, mouseY, delta);
     }
 }


### PR DESCRIPTION
Bumped dependencies to 1.19.4, and fixed mapping change in `src/main/java/re/domi/fastchest/config/ConfigScreen.java`

Video: https://cdn.frogg.ie/record-2023-05-25_13.32.53.mp4