### PR TITLE
No-op clientTick

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2021 - 2022 Domi
+Copyright (c) 2021-2023 Domi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.3
-	loader_version=0.13.3
+# check these on https://fabricmc.net/versions.html
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.3
+loader_version=0.13.3
 
 # Mod Properties
-	mod_version = 1.3+1.18
-	maven_group = re.domi
-	archives_base_name = fast-chest
+mod_version = 1.3+1.18
+maven_group = re.domi
+archives_base_name = fast-chest
 
 # Dependencies
-	fabric_version=0.47.8+1.18.2
-	mod_menu_version=3.0.0
+fabric_version=0.47.8+1.18.2
+mod_menu_version=3.0.0

--- a/src/main/java/re/domi/fastchest/mixin/BlockEntityRenderDispatcherMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/BlockEntityRenderDispatcherMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import re.domi.fastchest.config.Config;
 
 @Mixin(BlockEntityRenderDispatcher.class)
-public class BlockEntityRenderDispatcherMixin
+public abstract class BlockEntityRenderDispatcherMixin
 {
     @Inject(method = "get", at = @At("HEAD"), cancellable = true)
     private <E extends BlockEntity> void fastchest_get(E blockEntity, CallbackInfoReturnable<@Nullable BlockEntityRenderer<E>> cir)

--- a/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
@@ -1,0 +1,19 @@
+package re.domi.fastchest.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.ChestBlockEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(ChestBlockEntity.class)
+public abstract class ChestBlockEntityMixin
+{
+    /**
+     * @author Fury_Phoenix
+     * @reason No-op animation, also stops EBE animations
+     **/
+    @Overwrite
+    public static void clientTick(World w, BlockPos p, BlockState s, ChestBlockEntity c){}
+}

--- a/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(ChestBlockEntity.class, priority = 2000)
+@Mixin(value = ChestBlockEntity.class, priority = 2000)
 public abstract class ChestBlockEntityMixin
 {
     /**

--- a/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/ChestBlockEntityMixin.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(ChestBlockEntity.class)
+@Mixin(ChestBlockEntity.class, priority = 2000)
 public abstract class ChestBlockEntityMixin
 {
     /**

--- a/src/main/java/re/domi/fastchest/mixin/ChestBlockMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/ChestBlockMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import re.domi.fastchest.config.Config;
 
 @Mixin(ChestBlock.class)
-public class ChestBlockMixin
+public abstract class ChestBlockMixin
 {
     @Inject(method = "getRenderType", at = @At("HEAD"), cancellable = true)
     private void fastchest_getRenderType(BlockState state, CallbackInfoReturnable<BlockRenderType> cir)

--- a/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(EnderChestBlockEntity.class)
+@Mixin(EnderChestBlockEntity.class, priority = 2000)
 public abstract class EnderChestBlockEntityMixin
 {
     /**

--- a/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(EnderChestBlockEntity.class, priority = 2000)
+@Mixin(value = EnderChestBlockEntity.class, priority = 2000)
 public abstract class EnderChestBlockEntityMixin
 {
     /**

--- a/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/EnderChestBlockEntityMixin.java
@@ -1,0 +1,19 @@
+package re.domi.fastchest.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.EnderChestBlockEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(EnderChestBlockEntity.class)
+public abstract class EnderChestBlockEntityMixin
+{
+    /**
+     * @author Fury_Phoenix
+     * @reason No-op animation, also stops EBE animations
+     **/
+    @Overwrite
+    public static void clientTick(World w, BlockPos p, BlockState s, EnderChestBlockEntity c){}
+}

--- a/src/main/java/re/domi/fastchest/mixin/EnderChestBlockMixin.java
+++ b/src/main/java/re/domi/fastchest/mixin/EnderChestBlockMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import re.domi.fastchest.config.Config;
 
 @Mixin(EnderChestBlock.class)
-public class EnderChestBlockMixin
+public abstract class EnderChestBlockMixin
 {
     @Inject(method = "getRenderType", at = @At("HEAD"), cancellable = true)
     private void fastchest_getRenderType(BlockState state, CallbackInfoReturnable<BlockRenderType> cir)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,7 @@
     "Domi"
   ],
   "contributors": [
-    "eeasee"
+    "eeasee", "Fury_Phoenix"
   ],
   "contact": {
     "homepage": "https://domi.re/mc-mods/fastchest",

--- a/src/main/resources/fc.mixins.json
+++ b/src/main/resources/fc.mixins.json
@@ -8,7 +8,9 @@
   "client": [
     "BlockEntityRenderDispatcherMixin",
     "ChestBlockMixin",
-    "EnderChestBlockMixin"
+    "ChestBlockEntityMixin",
+    "EnderChestBlockMixin",
+    "EnderChestBlockEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Currently as it is, models are static. But the clientTick function still runs anyway, and can be significant. For instance, a bunker with lots of chests took up about 2-3% of the render thread time.
This PR brings some minor cleanup, and turns `clientTick` into a no-op. As well, a 2nd PR to master branch is provided with merge conflicts resolved.